### PR TITLE
Update .env.example to give user connected to Docker MySQL root access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,13 +12,12 @@
 # MySQL credentials for Docker
 # Add anything you want for these credentials to your .env file
 MYSQL_DATABASE=""
-MYSQL_USER=""
-MYSQL_PASSWORD=""
+MYSQL_USER="root"
 MYSQL_ROOT_PASSWORD=""
 
 # Prisma
 # https://www.prisma.io/docs/reference/database-reference/connection-urls#env
-DATABASE_URL="mysql://${MYSQL_USER}:${MYSQL_PASSWORD}@localhost:3300/${MYSQL_DATABASE}"
+DATABASE_URL="mysql://${MYSQL_USER}:${MYSQL_ROOT_PASSWORD}@localhost:3300/${MYSQL_DATABASE}"
 
 # Next Auth
 # You can generate a new secret on the command line with:

--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ MYSQL_ROOT_PASSWORD=""
 
 # Prisma
 # https://www.prisma.io/docs/reference/database-reference/connection-urls#env
-DATABASE_URL="mysql://root:${MYSQL_ROOT_PASSWORD}@localhost:3300/${MYSQL_DATABASE}"
+DATABASE_URL="mysql://root:${MYSQL_ROOT_PASSWORD}@mysql:3306/${MYSQL_DATABASE}"
 
 # Next Auth
 # You can generate a new secret on the command line with:

--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,10 @@ MYSQL_ROOT_PASSWORD=""
 
 # Prisma
 # https://www.prisma.io/docs/reference/database-reference/connection-urls#env
+# database url for local mysql server
+DATABASE_URL="mysql://root:${MYSQL_ROOT_PASSWORD}@localhost:3306/${MYSQL_DATABASE}"
+
+# database url for mysql docker container
 DATABASE_URL="mysql://root:${MYSQL_ROOT_PASSWORD}@mysql:3306/${MYSQL_DATABASE}"
 
 # Next Auth

--- a/.env.example
+++ b/.env.example
@@ -12,12 +12,11 @@
 # MySQL credentials for Docker
 # Add anything you want for these credentials to your .env file
 MYSQL_DATABASE=""
-MYSQL_USER="root"
 MYSQL_ROOT_PASSWORD=""
 
 # Prisma
 # https://www.prisma.io/docs/reference/database-reference/connection-urls#env
-DATABASE_URL="mysql://${MYSQL_USER}:${MYSQL_ROOT_PASSWORD}@localhost:3300/${MYSQL_DATABASE}"
+DATABASE_URL="mysql://root:${MYSQL_ROOT_PASSWORD}@localhost:3300/${MYSQL_DATABASE}"
 
 # Next Auth
 # You can generate a new secret on the command line with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@
 # Use node 18 image
 FROM node:18
 
+# Install Prisma globally
+RUN npm install -g prisma
+
 # Create the directory on the node image 
 # where our Next.js app will live
 RUN mkdir -p /app

--- a/README.md
+++ b/README.md
@@ -19,14 +19,19 @@ Docker is used to containerized our application so that you don't have to run mu
 3. Fill in the necessary information for the _.env_ file
 4. Run `npm run docker:build` to build the containers (you only have to do this once).
 5. Run `npm run docker:up` to start the containers.
+6. (optional): To access the NextJS image terminal, run the command `docker exec -it nextjs sh`. This might be useful for install new packages to the NextJS image.
 
 You can now use the `MySQL` credentials stored in the _.env_ file to connect the `MySQL` server using your favorite database management tool..
 
 To stop the running containers, run `npm run docker:down` or press `CTRL-C`.
 
-To remove remove volumes from docker-compose: docker-compose down -v
+To remove volumes from docker-compose: docker-compose down -v
 
 To run command inside a docker container: docker exec -it {CONTAINER_NAME} sh -c "{COMMAND}"
+
+**For example:**
+
+When installing a package, you would run `npm install {PACKAGE}` in your local terminal. Your local environment is not sync with the NextJS docker image. Hence, you would also need to install the same package in the NextJS docker image as well by running this command `docker exec -it nextjs sh -c "npm install {PACKAGE}"`. Similar process for uninstall a package from your local environment.
 
 **Setting up MySQL database in Docker container:**
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ You can now use the `MySQL` credentials stored in the _.env_ file to connect the
 
 To stop the running containers, run `npm run docker:down` or press `CTRL-C`.
 
+To remove remove volumes from docker-compose: docker-compose down -v
+
+To run command inside a docker container: docker exec -it {CONTAINER_NAME} sh -c "{COMMAND}"
+
+**Setting up MySQL database in Docker container:**
+
+1. Add new connection
+2. Enter connection name, e.g. Docker MySQL
+3. Change the default port from 3306 to 3300
+4. Enter the username (default to **root**) and password (from the .env you entered) for the database connection
+
+Once connected, run the following commands to run migrations on your database:
+
+```
+docker exec -it nextjs sh -c "npx prisma migrate dev"
+```
+
 ## Sonar
 
 Sonar scans the repository to check for potential bugs, formatting issues, coverage, and much more. The sonar utility can be run using `npm run scan` which is just an alias for the `sonar-scanner` command. Sonar requires manual configuration to setup at this time.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   mysql:
     image: mysql
+    container_name: mysql
     ports:
       - "3300:3306"
     restart: always
@@ -16,6 +17,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    container_name: nextjs
     depends_on:
       - mysql
     ports:


### PR DESCRIPTION
<!--- Please remember to tie this PR to your associated story issue (if there is one) -->

## User Story
<!--- Copy and paste user story from zenhub -->

## Acceptance
<!--- Place your acceptance checklist here. Make not of any criteria that was changed and why. -->

## Summary of Changes
<!--- Technical outline of the changes introduced in this PR -->
There was a problem with not being able to create prisma migration using the {MYSQL_USER} and {MYSQL_PASSWORD}.

Hence, I've updated the .env.example file to ensure that the user connected to the MySQL docker container has full root access to the database by using {MYSQL_USER} and {MYSQL_ROOT_PASSWORD} instead for the MySQL docker container.

## Noteworthy Mentions
<!--- Add anything important a reviewer/other developer might want to know -->
Make sure to update your credentials for the .env file

## Screenshots
<!--- Provide any relevant screenshots of the new features -->